### PR TITLE
Fixed issue with sorting items that have the same name, but different components

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21+build.2
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.1.1+1.21
+mod_version=1.1.2+1.21
 maven_group=borknbeans.lightweightinventorysorting
 archives_base_name=lightweight-inventory-sorting
 

--- a/src/client/java/borknbeans/lightweightinventorysorting/SortableSlot.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/SortableSlot.java
@@ -27,7 +27,15 @@ public class SortableSlot implements Comparable<SortableSlot> {
 
     @Override
     public int compareTo(@NotNull SortableSlot o) {
+        // Compare the names of the two stacks
         int result = LightweightInventorySortingConfig.sortType.compare(this.getStack(), o.getStack());
-        return result != 0 ? result : (o.getStack().getCount() - this.getStack().getCount());
+
+        if (result != 0) { // Items have different names
+            return result;
+        } else if (!ItemStack.areItemsAndComponentsEqual(this.getStack(), o.getStack())) { // Items have the same name, but different components or items
+            return 0;
+        } else { // Items have same name, are same item, and have same components
+            return o.getStack().getCount() - this.getStack().getCount();
+        }
     }
 }

--- a/src/client/java/borknbeans/lightweightinventorysorting/sorting/SortingHelper.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/sorting/SortingHelper.java
@@ -1,5 +1,6 @@
 package borknbeans.lightweightinventorysorting.sorting;
 
+import borknbeans.lightweightinventorysorting.LightweightInventorySorting;
 import borknbeans.lightweightinventorysorting.SortableSlot;
 import borknbeans.lightweightinventorysorting.SortableSlotComparator;
 import borknbeans.lightweightinventorysorting.config.LightweightInventorySortingConfig;
@@ -21,12 +22,15 @@ public class SortingHelper {
         DefaultedList<Slot> slots = client.player.currentScreenHandler.slots;
         List<SortableSlot> sortableSlots = new ArrayList<>();
 
+        String insightLog = "Starting sort...";
         for (int i = startIndex; i <= endIndex; i++) {
             ItemStack stack = slots.get(i).getStack();
             if (stack.isEmpty()) { continue; }
 
+            insightLog += "\n" + i + ": " + stack.getName().getString() + ", " + stack.getCount() + "/" + stack.getMaxCount() + ", " + stack.getItem().getName().getString();
             sortableSlots.add(new SortableSlot(i, stack));
         }
+        LightweightInventorySorting.LOGGER.info(insightLog);
 
         sortableSlots.sort(new SortableSlotComparator());
 

--- a/src/client/java/borknbeans/lightweightinventorysorting/sorting/SortingHelper.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/sorting/SortingHelper.java
@@ -61,9 +61,10 @@ public class SortingHelper {
             for (int j = index; j >= 0; j--) {
                 ItemStack stackPrev = sortedSlots.get(j).getStack();
 
-                // If we are holding something and the prev does not match OR if our hand is empty and the two checked stacks dont match
-                if ((hand.item != null && !stackPrev.isOf(hand.item) || (!stack.isOf(stackPrev.getItem()) && !hand.exists))) {
-                    if (hand.exists) {
+                // If we are holding something and the prev does not match OR if our hand is empty and the two checked stacks don't match
+                // THEN don't combine
+                if ((hand.stack != null && ItemStack.areItemsAndComponentsEqual(stackPrev, hand.stack) || (!ItemStack.areItemsAndComponentsEqual(stack, stackPrev) && !hand.exists))) {
+                    if (hand.exists) { // Place item in hand back down
                         move(client, syncId, 0, sortedSlots.get(i).getIndex(), hand);
                         hand.Reset();
                     }
@@ -85,7 +86,7 @@ public class SortingHelper {
                     move(client, syncId, sortedSlots.get(i).getIndex(), sortedSlots.get(j).getIndex(), hand);
                     // Store hand item information
                     hand.exists = true;
-                    hand.item = stackPrev.getItem();
+                    hand.stack = stackPrev;
                     hand.count = combinedCount - stackPrev.getMaxCount();
                 }
             }
@@ -150,7 +151,7 @@ public class SortingHelper {
 
         if (!destStack.isEmpty()) {
             hand.exists = true;
-            hand.item = destStack.getItem();
+            hand.stack = destStack;
             hand.count = destStack.getCount();
 
             // Get item in slot dest
@@ -176,7 +177,7 @@ public class SortingHelper {
 
 class HandHelper {
     public boolean exists;
-    public Item item;
+    public ItemStack stack;
     public int count;
 
     public HandHelper() {
@@ -185,7 +186,7 @@ class HandHelper {
 
     public void Reset() {
         exists = false;
-        item = null;
+        stack = null;
         count = 0;
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
 	"schemaVersion": 1,
 	"id": "lightweight-inventory-sorting",
-	"version": "1.1.1+1.21",
+	"version": "1.1.2+1.21",
 	"name": "Lightweight Inventory Sorting",
 	"description": "Lightweight client-side inventory Sorting with no extra fluff",
 	"authors": [


### PR DESCRIPTION
I.e. potions with same type but different durations, or tipped arrows