### PR TITLE
Add creative inventory sort

### DIFF
--- a/src/client/java/borknbeans/lightweightinventorysorting/config/SortTypes.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/config/SortTypes.java
@@ -1,10 +1,12 @@
 package borknbeans.lightweightinventorysorting.config;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 public enum SortTypes {
     ALPHANUMERIC,
-    REVERSE_ALPHANUMERIC;
+    REVERSE_ALPHANUMERIC,
+    INVENTORY;
 
     public int compare(ItemStack left, ItemStack right) {
         switch (this) {
@@ -12,6 +14,8 @@ public enum SortTypes {
                 return alphanumeric(left, right);
             case REVERSE_ALPHANUMERIC:
                 return reverseAlphanumeric(left, right);
+			case INVENTORY:
+                return inventory(left, right);
         }
 
         return 0;
@@ -35,5 +39,15 @@ public enum SortTypes {
         }
 
         return (left.getName().getString().compareTo(right.getName().getString())) * -1;
+    }
+
+    private int inventory(ItemStack left, ItemStack right) {
+        if (left.isEmpty() && !right.isEmpty()) {
+            return 0;
+        } else if (right.isEmpty() && !left.isEmpty()) {
+            return -1;
+        }
+
+        return Integer.compare(Item.getRawId(left.getItem()), Item.getRawId(right.getItem()));
     }
 }


### PR DESCRIPTION
Implements #12 (sort of...)

Sorts by the old way items were in the creative inventory. Recently it was changed to group items by type and in a more organized manner. I do not know how to sort by this new way but this is at least a start.