### PR TITLE
Add default ID sorting mode and Polish translation

### DIFF
--- a/src/client/java/borknbeans/lightweightinventorysorting/config/SortTypes.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/config/SortTypes.java
@@ -1,24 +1,23 @@
 package borknbeans.lightweightinventorysorting.config;
 
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
 
 public enum SortTypes {
     ALPHANUMERIC,
     REVERSE_ALPHANUMERIC,
+    DEFAULT_ID,
     RAW_ID;
 
     public int compare(ItemStack left, ItemStack right) {
-        switch (this) {
-            case ALPHANUMERIC:
-                return alphanumeric(left, right);
-            case REVERSE_ALPHANUMERIC:
-                return reverseAlphanumeric(left, right);
-			case RAW_ID:
-                return rawId(left, right);
-        }
-
-        return 0;
+        return switch (this) {
+            case ALPHANUMERIC -> alphanumeric(left, right);
+            case REVERSE_ALPHANUMERIC -> reverseAlphanumeric(left, right);
+            case DEFAULT_ID -> defaultId(left, right);
+            case RAW_ID -> rawId(left, right);
+        };
     }
 
     private int alphanumeric(ItemStack left, ItemStack right) {
@@ -39,6 +38,17 @@ public enum SortTypes {
         }
 
         return (left.getName().getString().compareTo(right.getName().getString())) * -1;
+    }
+
+    private int defaultId(ItemStack left, ItemStack right) {
+        if (left.isEmpty() && !right.isEmpty()) {
+            return 0;
+        } else if (right.isEmpty() && !left.isEmpty()) {
+            return -1;
+        }
+
+        final Text leftName = left.getOrDefault(DataComponentTypes.ITEM_NAME, null), rightName = right.getOrDefault(DataComponentTypes.ITEM_NAME, null);
+        return (leftName == null ? "" : leftName.getString()).compareTo(rightName == null ? "" : rightName.getString());
     }
 
     private int rawId(ItemStack left, ItemStack right) {

--- a/src/main/resources/assets/lightweight-inventory-sorting/lang/en_us.json
+++ b/src/main/resources/assets/lightweight-inventory-sorting/lang/en_us.json
@@ -7,7 +7,7 @@
 
   "category.lightweight-inventory-sorting.sort-options": "Sorting Options",
   "category.lightweight-inventory-sorting.sort-type": "Sorting Type",
-  "category.lightweight-inventory-sorting.sort-type-tooltip": "Alphanumeric (A-Z), Reverse Alphanumeric (Z-A), or by Raw IDs",
+  "category.lightweight-inventory-sorting.sort-type-tooltip": "Alphanumeric (A-Z), Reverse Alphanumeric (Z-A), or by default or raw IDs",
   "category.lightweight-inventory-sorting.sort-delay": "Sorting Delay",
   "category.lightweight-inventory-sorting.sort-delay-tooltip": "Increase delay between sorting steps (useful for multiplayer server errors)",
 

--- a/src/main/resources/assets/lightweight-inventory-sorting/lang/pl_pl.json
+++ b/src/main/resources/assets/lightweight-inventory-sorting/lang/pl_pl.json
@@ -7,7 +7,7 @@
 
   "category.lightweight-inventory-sorting.sort-options": "Opcje sortowania",
   "category.lightweight-inventory-sorting.sort-type": "Typ sortowania",
-  "category.lightweight-inventory-sorting.sort-type-tooltip": "Alfanumerycznie (A-Z), alfanumerycznie malejąco (Z-A), lub po surowym ID",
+  "category.lightweight-inventory-sorting.sort-type-tooltip": "Alfanumerycznie (A-Z), alfanumerycznie malejąco (Z-A), albo po słownym lub surowym ID",
   "category.lightweight-inventory-sorting.sort-delay": "Opóźnienie sortowania",
   "category.lightweight-inventory-sorting.sort-delay-tooltip": "Zwiększa opóźnienie między kolejnymi krokami sortowania (przydatne aby zapobiec błędom na serwerach wieloosobowych)",
 

--- a/src/main/resources/assets/lightweight-inventory-sorting/lang/pl_pl.json
+++ b/src/main/resources/assets/lightweight-inventory-sorting/lang/pl_pl.json
@@ -1,0 +1,24 @@
+{
+  "key.lightweight-inventory-sorting.sort": "Posortuj bieżący pojemnik/ekwipunek",
+
+  "category.lightweight-inventory-sorting.title": "Lightweight Inventory Sorting",
+
+  "category.lightweight-inventory-sorting.general": "Ustawienia ogólne",
+
+  "category.lightweight-inventory-sorting.sort-options": "Opcje sortowania",
+  "category.lightweight-inventory-sorting.sort-type": "Typ sortowania",
+  "category.lightweight-inventory-sorting.sort-type-tooltip": "Alfanumerycznie (A-Z), alfanumerycznie malejąco (Z-A), lub po surowym ID",
+  "category.lightweight-inventory-sorting.sort-delay": "Opóźnienie sortowania",
+  "category.lightweight-inventory-sorting.sort-delay-tooltip": "Zwiększa opóźnienie między kolejnymi krokami sortowania (przydatne aby zapobiec błędom na serwerach wieloosobowych)",
+
+  "category.lightweight-inventory-sorting.button-options": "Opcje przycisku",
+  "category.lightweight-inventory-sorting.button-size": "Rozmiar przycisku",
+  "category.lightweight-inventory-sorting.inventory-x": "Przesunięcie w osi X w ekwipunku",
+  "category.lightweight-inventory-sorting.inventory-x-tooltip": "Wartość dodatnia przesuwa w prawo, wartość ujemna w lewo",
+  "category.lightweight-inventory-sorting.inventory-y": "Przesunięcie w osi Y w ekwipunku",
+  "category.lightweight-inventory-sorting.inventory-y-tooltip": "Wartość dodatnia przesuwa w dół, wartość ujemna w górę",
+  "category.lightweight-inventory-sorting.container-x": "Przesunięcie w osi X w pojemniku",
+  "category.lightweight-inventory-sorting.container-x-tooltip": "Wartość dodatnia przesuwa w prawo, wartość ujemna w lewo",
+  "category.lightweight-inventory-sorting.container-y": "Przesunięcie w osi Y w pojemniku",
+  "category.lightweight-inventory-sorting.container-y-tooltip": "Wartość dodatnia przesuwa w dół, wartość ujemna w górę"
+}

--- a/src/main/resources/assets/lightweight-inventory-sorting/lang/pt_br.json
+++ b/src/main/resources/assets/lightweight-inventory-sorting/lang/pt_br.json
@@ -7,7 +7,7 @@
 
   "category.lightweight-inventory-sorting.sort-options": "Opções de organização",
   "category.lightweight-inventory-sorting.sort-type": "Tipo de organização",
-  "category.lightweight-inventory-sorting.sort-type-tooltip": "Alfanumérico (A-Z) ou Alfanumérico reverso (Z-A)",
+  "category.lightweight-inventory-sorting.sort-type-tooltip": "Alfanumérico (A-Z), Alfanumérico reverso (Z-A), ou por ID padrão ou bruto",
   "category.lightweight-inventory-sorting.sort-delay": "Atraso de organização",
   "category.lightweight-inventory-sorting.sort-delay-tooltip": "Aumenta o atraso entre etapas de organização (útil para erros em servidores multiplayer)",
 


### PR DESCRIPTION
The intention of this mode is to sort items by their ID (like `minecraft:stone`, not raw numeric ID), so that items like `minecraft:iron_block`, `minecraft:iron_ingot` and `minecraft:iron_nugget` are always placed next to each other.