### PR TITLE
Migrate screens and sort button to 1.21.10 input API (KeyInput/Click)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,17 +5,17 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
-loader_version=0.17.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.17.3
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=1.1.4+1.21.8
+mod_version=1.1.4+1.21.10
 maven_group=borknbeans.lightweightinventorysorting
 archives_base_name=lightweight-inventory-sorting
 
 # Dependencies
-fabric_version=0.132.0+1.21.8
+fabric_version=0.136.0+1.21.10
 modmenu_version=15.0.0-beta.3
 cloth_version=19.0.147

--- a/src/client/java/borknbeans/lightweightinventorysorting/LightweightInventorySortingClient.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/LightweightInventorySortingClient.java
@@ -10,6 +10,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.*;
@@ -27,11 +28,12 @@ public class LightweightInventorySortingClient implements ClientModInitializer {
 	}
 
 	private void registerKeyBindings() {
+        KeyBinding.Category titleCategory = KeyBinding.Category.create(Identifier.of("category.lightweight-inventory-sorting.title"));
 		sortKeyBind = KeyBindingHelper.registerKeyBinding(new KeyBinding(
 			"key.lightweight-inventory-sorting.sort",
 			InputUtil.Type.KEYSYM,
 			GLFW.GLFW_KEY_R,
-			"category.lightweight-inventory-sorting.title"
+			titleCategory
 		));
 	}
 

--- a/src/client/java/borknbeans/lightweightinventorysorting/mixin/client/GenericContainerScreenMixin.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/mixin/client/GenericContainerScreenMixin.java
@@ -4,9 +4,12 @@ package borknbeans.lightweightinventorysorting.mixin.client;
 import borknbeans.lightweightinventorysorting.LightweightInventorySortingClient;
 import borknbeans.lightweightinventorysorting.config.Config;
 import borknbeans.lightweightinventorysorting.sorting.SortButton;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.input.KeyInput;
+import net.minecraft.client.input.MouseInput;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.GenericContainerScreenHandler;
 import net.minecraft.text.Text;
@@ -47,20 +50,22 @@ public abstract class GenericContainerScreenMixin extends HandledScreen<GenericC
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (LightweightInventorySortingClient.sortKeyBind.matchesKey(keyCode, scanCode)) {
-            sortButton.onClick(0f, 0f); // Simulate a click
+    public boolean keyPressed(KeyInput keyInput) {
+        if (LightweightInventorySortingClient.sortKeyBind.matchesKey(keyInput)) {
+            sortButton.onPress(new MouseInput(0,0));
+            return true;
         }
 
-        return super.keyPressed(keyCode, scanCode, modifiers);
+        return super.keyPressed(keyInput);
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (LightweightInventorySortingClient.sortKeyBind.matchesMouse(button)) {
-            sortButton.onClick(0f, 0f); // Simulate a click
+    public boolean mouseClicked(Click click, boolean doubleClick) {
+        if (LightweightInventorySortingClient.sortKeyBind.matchesMouse(click)) {
+            sortButton.simulateClick(click); // Simulate a click
+            return true;
         }
 
-        return super.mouseClicked(mouseX, mouseY, button);
+        return super.mouseClicked(click, doubleClick);
     }
 }

--- a/src/client/java/borknbeans/lightweightinventorysorting/mixin/client/InventoryScreenMixin.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/mixin/client/InventoryScreenMixin.java
@@ -9,9 +9,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import borknbeans.lightweightinventorysorting.LightweightInventorySortingClient;
 import borknbeans.lightweightinventorysorting.config.Config;
 import borknbeans.lightweightinventorysorting.sorting.SortButton;
+
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.input.KeyInput;
+import net.minecraft.client.input.MouseInput;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.text.Text;
@@ -43,24 +47,28 @@ public abstract class InventoryScreenMixin extends HandledScreen<PlayerScreenHan
         }
     }
 
-    // This override is NOT an ideal solution as it could lead to conflicts with other mods
+    // Updated: uses KeyInput instead of (int, int, int)
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (LightweightInventorySortingClient.sortKeyBind.matchesKey(keyCode, scanCode)) {
-            sortButton.onClick(0f, 0f); // Simulate a click
+    public boolean keyPressed(KeyInput keyInput) {
+        if (LightweightInventorySortingClient.sortKeyBind.matchesKey(keyInput)) {
+            sortButton.onPress(new MouseInput(0,0)); // Simulate a click
+            return true;
         }
-        return super.keyPressed(keyCode, scanCode, modifiers);
+        return super.keyPressed(keyInput);
     }
 
+    // Updated: uses Click + boolean doubleClick
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (LightweightInventorySortingClient.sortKeyBind.matchesMouse(button)) {
-            sortButton.onClick(0f, 0f); // Simulate a click
+    public boolean mouseClicked(Click click, boolean doubleClick) {
+        if (LightweightInventorySortingClient.sortKeyBind.matchesMouse(click)) {
+            sortButton.simulateClick(click); // Simulate a click
+            return true;
         }
 
-        return super.mouseClicked(mouseX, mouseY, button);
+        return super.mouseClicked(click, doubleClick);
     }
     
+    @Unique
     private void setButtonCoordinates() {
         sortButton.setX(this.x + this.backgroundWidth - 20 + Config.xOffsetInventory);
         sortButton.setY(this.height / 2 - 15 + Config.yOffsetInventory);

--- a/src/client/java/borknbeans/lightweightinventorysorting/mixin/client/ShulkerBoxScreenMixin.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/mixin/client/ShulkerBoxScreenMixin.java
@@ -3,17 +3,23 @@ package borknbeans.lightweightinventorysorting.mixin.client;
 import borknbeans.lightweightinventorysorting.LightweightInventorySortingClient;
 import borknbeans.lightweightinventorysorting.config.Config;
 import borknbeans.lightweightinventorysorting.sorting.SortButton;
+
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.screen.ingame.ShulkerBoxScreen;
+import net.minecraft.client.input.KeyInput;
+import net.minecraft.client.input.MouseInput;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.ShulkerBoxScreenHandler;
 import net.minecraft.text.Text;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 
 @Mixin(ShulkerBoxScreen.class)
 public abstract class ShulkerBoxScreenMixin extends HandledScreen<ShulkerBoxScreenHandler> {
@@ -45,21 +51,24 @@ public abstract class ShulkerBoxScreenMixin extends HandledScreen<ShulkerBoxScre
         }
     }
 
+    // Updated to new signature
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (LightweightInventorySortingClient.sortKeyBind.matchesKey(keyCode, scanCode)) {
-            sortButton.onClick(0f, 0f); // Simulate a click
+    public boolean keyPressed(KeyInput keyInput) {
+        if (LightweightInventorySortingClient.sortKeyBind.matchesKey(keyInput)) {
+            sortButton.onPress(new MouseInput(0,0));
+            return true;
         }
 
-        return super.keyPressed(keyCode, scanCode, modifiers);
+        return super.keyPressed(keyInput);
     }
 
+    // Updated to new signature
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (LightweightInventorySortingClient.sortKeyBind.matchesMouse(button)) {
-            sortButton.onClick(0f, 0f); // Simulate a click
+    public boolean mouseClicked(Click click, boolean doubleClick) {
+        if (LightweightInventorySortingClient.sortKeyBind.matchesMouse(click)) {
+            sortButton.simulateClick(click); // Simulate a click
         }
 
-        return super.mouseClicked(mouseX, mouseY, button);
+        return super.mouseClicked(click, doubleClick);
     }
 }

--- a/src/client/java/borknbeans/lightweightinventorysorting/sorting/SortButton.java
+++ b/src/client/java/borknbeans/lightweightinventorysorting/sorting/SortButton.java
@@ -1,24 +1,22 @@
 package borknbeans.lightweightinventorysorting.sorting;
 
-import com.mojang.blaze3d.pipeline.RenderPipeline;
-
 import borknbeans.lightweightinventorysorting.LightweightInventorySorting;
 import borknbeans.lightweightinventorysorting.config.Config;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.gui.widget.ClickableWidget;
-import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.gui.widget.PressableWidget;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
-public class SortButton extends ClickableWidget {
+public class SortButton extends PressableWidget {
 
-    private Identifier buttonTexture;
-    private Identifier buttonHoverTexture;
+    private final Identifier buttonTexture;
+    private final Identifier buttonHoverTexture;
 
-    private int sortStartIndex, sortEndIndex;
+    private final int sortStartIndex, sortEndIndex;
 
     public SortButton(int x, int y, int width, int height, Text message, int startIndex, int endIndex) {
         super(x, y, width, height, message);
@@ -45,7 +43,7 @@ public class SortButton extends ClickableWidget {
     }
 
     @Override
-    public void onClick(double mouseX, double mouseY) {
+    public void onPress(net.minecraft.client.input.AbstractInput input) {
         MinecraftClient client = MinecraftClient.getInstance();
 
         if (client.player != null) {
@@ -54,6 +52,12 @@ public class SortButton extends ClickableWidget {
         } else {
             LightweightInventorySorting.LOGGER.error("Player is not available.");
         }
+    }
+
+    public void simulateClick(Click click){
+        // For simplicity, ignore coordinates and button type, just trigger onPress
+        // Convert Click → AbstractInput for onPress
+        this.onPress(click.buttonInfo());
     }
     
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.14",
-		"minecraft": "~1.21.8",
+		"minecraft": "~1.21.10",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
### Summary
This PR updates the mod to run on Minecraft/Fabric 1.21.10 (Yarn 1.21.10+build.2).  
Mojang/Fabric changed the client input API in this version (key/mouse events now use
`KeyInput`, `Click`, and `AbstractInput`), so the GUI mixins and the custom SortButton
needed to be adjusted.

### What changed
- updated `SortButton` to extend `PressableWidget` and to override
  `onPress(AbstractInput)` instead of the removed `onClick(...)`
- updated inventory/container/shulker screen mixins to use the new
  method signatures:
  - `keyPressed(KeyInput keyInput)`
  - `mouseClicked(Click click, boolean doubleClick)`
- replaced old key/mouse checks (`matchesKey(int, int)`, `matchesMouse(int)`)
  with the new ones that take the input objects
- kept button placement logic the same (still respects `Config.*` offsets)